### PR TITLE
Remove point about only main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ SSB-JS organization require discussion and consent.
 - The 'SSB-JS namespace' refers to the SSB-JS organizations on GitHub and Npm.
 - Repositories and build artifacts must be hosted in the SSB-JS namespace.
 - Repositories MUST have a 'main' branch.
-- Repositories MUST NOT have any other branches.
 
 ### Projects
 


### PR DESCRIPTION
Assuming #9 goes through, I think we need to lift the restriction that a repo can only have a main branch. Lets say I'm working on something that is not quite ready yet, I would rather do it on a branch in ssb-js, than having to fork the repo to my own profile.