### PR TITLE
Replace 'MUST' with 'SHOULD' for branch rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SSB-JS organization require discussion and consent.
 - The 'SSB-JS namespace' refers to the SSB-JS organizations on GitHub and Npm.
 - Repositories and build artifacts must be hosted in the SSB-JS namespace.
 - Repositories MUST have a 'main' branch.
-- Repositories MUST NOT have any other branches.
+- Repositories SHOULD NOT have any other branches.
 
 ### Projects
 


### PR DESCRIPTION
Problem: The 'MUST' language carries lots of weight, and should only be
used for fundamentals like 'governance patches MUST NOT be merged
without approval'. Having multiple branches in a repository isn't an
ideal, and we should try to remove them when we can, but it isn't the
end of the world if a maintainer uses it for a pull request.

Solution: Reduce 'MUST' to 'SHOULD' for the rule that says that
repositories shouldn't have any other branches. After this change, the
only 'MUST' rules are fundamentals that are absolutely necessary.

---

See also: #10 