### PR TITLE
Remove Maintainer rules about merging specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ SSB-JS organization require discussion and consent.
 - Maintainers SHOULD aim to make contributing a fun and simple experience.
 - Maintainers SHOULD merge project pull requests in a fast and friendly manner.
 - Maintainers SHOULD merge project pull requests that are net positive and pass tests.
-- Maintainers SHOULD NOT suggest small improvements on project pull requests.
-- Maintainers SHOULD suggest their improvements by opening their own pull request.
 - Maintainers SHOULD close pull requests that are inactive for more than 30 days.
 - Maintainers SHOULD invite high-quality contributors to become maintainers.
 - Maintainers SHOULD remove anyone who fails to apply this process.


### PR DESCRIPTION
I'm proposing to remove 2 rules that have been somewhat contentious in an SSB thread (`%9TGNIbIqh4MUk7zQAhHETld5ynebiimHE3pdJgU/vWg=.sha256`). 

I think line 70 ("*Maintainers SHOULD merge project pull requests in a fast and friendly manner.*") is a really good one that covers in a broad sense what the PR merging experience should look line, and the proposed removed lines are more specific and seem to bring disagreement.

To address each one:

> Maintainers SHOULD NOT suggest small improvements on project pull requests.

"Small improvements" could be interpreted in various ways, they could be anything between "remove code style changes that are inconsistent with the project" and "replace `const x = foo.x` with `const {x} = foo`" (arguably a nitpick). The fact that maintainers are not supposed to ask or suggest *any* small improvements is contentious and I think we will do better by trusting the maintainers that we chose, and keeping this README high-level, not specific. 

> Maintainers SHOULD suggest their improvements by opening their own pull request.

This one says "improvements", not "small improvements", giving the impression that maintainers should not suggest anything at all to a contributor's PR. 

More importantly, it assumes that maintainers also should not **add** commits to the PR. I think Git gives us many ways of solving issues such as adding commits to the PR, as well as squash-and-merge. @christianbundy expressed in SSB that he dislikes squash-and-merge, but I see it being often very useful for a friendly contribution workflow. I think this README should refrain from specific Git guidelines, and trust the maintainers to keep a friendly contribution environment, regardless of their preferred Git strategies.