### PR TITLE
Remove "30 days" PR age

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ SSB-JS organization require discussion and consent.
 - Maintainers SHOULD merge project pull requests that are net positive and pass tests.
 - Maintainers SHOULD NOT suggest small improvements on project pull requests.
 - Maintainers SHOULD suggest their improvements by opening their own pull request.
-- Maintainers SHOULD close pull requests that are inactive for more than 30 days.
+- Maintainers SHOULD close pull requests that are outdated in comparison to the `main` branch.
 - Maintainers SHOULD invite high-quality contributors to become maintainers.
 - Maintainers SHOULD remove anyone who fails to apply this process.
 


### PR DESCRIPTION
This PR proposes to relax the rule about PRs being closed after 30 days.

Reasoning: I believe that issues and PRs don't become stale with time. Calendar time doesn't make the issues go away, or the PRs to become irrelevant. It's the commit history on `main` branch that makes issues go away or PR to become irrelevant. I've seen plenty of (also SSB) repos that had old issues that were still quite important about code currently in the master branch. I've also seen PRs like that.

What matters is when a PR has not had updates while the `main` branch has moved on considerably, and potentially many git conflicts have arisen.