### PR TITLE
Add link to RFC 2119 requirement levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ SSB-JS organization require discussion and consent.
 
 ## Process
 
+- The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
 ### Repositories
 
 - There MUST be one Git repository for governance and one for each project.


### PR DESCRIPTION
I'm worried that the recent discussion around 'SHOULD' items (e.g.
maintainers requesting changes) might be stemming from different
interpretations of 'SHOULD' requirement.

This commit disambiguates the requirement levels by defining them, which
explains that 'SHOULD' describes the happy path, not an absolute
requirement. I think it's useful to define what our ideals are so that
we can strive for them, but we should also trust maintainers to use
their best judgment when these ideals interfere with reality.