### PR TITLE
Remove contributor PR update requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ SSB-JS organization require discussion and consent.
 ### Contributors
 
 - 'Contributors' are anyone who participates in a project.
-- Contributors MUST read a project's CONTRIBUTING.md before submitting a pull request.
-- Contributors MUST update their pull requests until they have no blocking concerns.
 - Contributors MUST aim to foster an open, welcoming, and harassment-free space.
+- Contributors MUST read a project's CONTRIBUTING.md before submitting a pull request.
 - Contributors SHOULD recommend changes in the form of patches.
 - Contributors who want to be maintainers SHOULD participate consistently and often.
 


### PR DESCRIPTION
Problem: I don't think that we can make a requirement (especially a
'MUST' requirement) that contributors follow maintainer suggestions in
their patch.

Solution: We could add a "or close their pull request" suffix, but since
maintainers are tasked with closing out-of-date pull requests I don't
think that we need to put that responsibility on contributors. My
preferred solution would be to remove this requirement from
contributors. This commit also rearranges the lines so that the
harassment policy isn't in the middle of the PR policy.

---

Note: This is only for @staltz, the PR is being opened into SSB-JS because that's where the branch is.