### PR TITLE
Default to Prettier and ESlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ SSB-JS organization require discussion and consent.
 
 - Projects SHOULD be written in JavaScript or TypeScript.
 - Projects SHOULD have internally consistent code style.
+  - Projects SHOULD follow the default [Prettier](https://prettier.io/) rules.
+  - Projects SHOULD follow the [recommended ESLint rules](https://eslint.org/docs/rules/).
 - Projects SHOULD have documentation of all public APIs.
 - Projects SHOULD have automated tests for all target platforms.
 - Projects SHOULD have internally consistent contribution guidelines.


### PR DESCRIPTION
Our modules don't conform to any style guide for code formatting or
code quality, which means we all pull toward our personal preference
rather than some 'good enough' middle ground that we can all agree on.

Common style guides make cooperation easier and create a high-pass
filter for disagreements and churn. Automatic code formatting and
code-quality rules are helpful to set expectations that are accessible
and predictable.

Writing a style guide takes lots of work, and there's a large risk that
any custom style guide will be unfamiliar to the vast majority of people
who want to contribute to our projects. My preference is to use style
guides which are popular (familiar) and uncontroversial (boring), which
should make the style guide resistant to unnecessary future churn.

This commit adds a rule to default to Prettier and ESLint, which gives
us code formatting rules for most languages and code-quality rules for
languages that are compatible with ESLint (JavaScript, JSX, TypeScript,
and others).

Fixes: https://github.com/ssb-js/ssb-js/issues/25